### PR TITLE
Return the logger object from logfmt.time

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -61,7 +61,11 @@ exports.time = function(arg1, arg2, arg3) {
     self.log(data, stream);
   }
 
-  return callback(logger);
+  if (typeof callback === 'function') {
+    callback(logger);
+  }
+
+  return logger;
 }
 
 exports.namespace = function(object){

--- a/test/log_time.js
+++ b/test/log_time.js
@@ -80,6 +80,28 @@ suite('logfmt.time', function() {
     })
   })
 
+  test("calls the callback if provided", function(){
+    var test;
+    logfmt.time(function(logger){
+      test = true;
+    });
+    assert(test);
+  })
+
+  test("does not call the callback if not provided", function(){
+    assert.doesNotThrow(function(){
+      logfmt.time();
+    });
+  })
+
+  test("returns a logger", function(){
+    var logger1, logger2;
+    logger1 = logfmt.time(function(logger){
+      logger2 = logger;
+    });
+    assert.equal(logger1, logger2);
+  })
+
   // tests you can pass the logger into a closure
   // and call `log` multiple times.
   // uses setTimeout to ensure the timing happens in 20ms


### PR DESCRIPTION
There's really no need for a callback here at all, is there?

``` javascript
var logger = logfmt.time();

// do some stuff

logger.log({ success: true });
```
