### PR TITLE
V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,20 @@ logfmt.log({hello: 'world'})
 //=> app=logfmt hello=world
 ```
 
-### `logfmt.time([label], [data], [callback(logger)])`
-
-#### `logger.log([data], [stream])`
+### `logfmt.time([label], [data], [callback(logfmt)])`
 
 Log how long something takes.
 
 - `label`: optional name for the milliseconds key (defaults to `elapsed`)
 - `data`: optional extra data to include with every call to `logger.log`
-- `logger`: object passed to callback with a `log` function
+- `callback(logfmt)`: new logfmt object passed to callback
+
+If you don't pass in callback you get the logger returned.
+```javascript
+var logfmt2 = logfmt.time();
+logfmt2.log();
+//=> elapsed=1ms
+```
 
 No args defaults to `elapsed=<milliseconds>ms`
 
@@ -96,13 +101,6 @@ No args defaults to `elapsed=<milliseconds>ms`
 logfmt.time(function(logger){
   logger.log();
 })
-//=> elapsed=1ms
-```
-
-If you don't pass in callback you get the logger returned.
-```javascript
-var logger = logfmt.time();
-logger.log();
 //=> elapsed=1ms
 ```
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,7 +15,7 @@ exports.log = function(data, stream) {
     }
     else value = value.toString();
 
-    var needs_quoting = value.indexOf(' ') > -1 || value.indexOf('=') > -1;
+    var needs_quoting  = value.indexOf(' ') > -1 || value.indexOf('=') > -1;
     var needs_escaping = value.indexOf('"') > -1;
 
     if(needs_escaping) value = value.replace(/"/g, '\\"');
@@ -37,12 +37,16 @@ exports.time = function(arg1, arg2, arg3) {
   var callback = arg3;
 
   if(!arg2){
-    label = 'elapsed';
-    callback = arg1;
+    if(typeof arg1  === 'function'){
+      label = 'elapsed';
+      callback = arg1;
+    }
   }
   else if(!arg3){
-    if(arg1.substring){
+    //using method detection
+    if(typeof arg1 === 'string'){
       label = arg1;
+      top_data = {};
     }else{
       label = 'elapsed';
       top_data = arg1;
@@ -50,30 +54,14 @@ exports.time = function(arg1, arg2, arg3) {
     callback = arg2;
   }
 
-  var logger = {};
-  var self = this;
+  var logger = this.namespace(top_data);
+  var orig_log = logger.log;
+
   logger.log = function(data, stream){
     var now = (new Date()).getTime()
-    if(!data) data = {};
-    for (key in top_data) {
-      data[key] = top_data[key];
-    }
+    data = data || {};
     data[label] = (now - startTime).toString() + 'ms' ;
-    var stream = stream || self.stream
-    self.log(data, stream);
-  }
-
-  logger.error = function(err, stream){
-    var now = (new Date()).getTime()
-    var id = Math.random().toString().slice(2, 12);
-    data = { error:true, id:id };
-    for (key in top_data) {
-      data[key] = top_data[key];
-    }
-    data[label] = (now - startTime).toString() + 'ms';
-    var stream = stream || self.stream;
-    self.log(data, stream);
-    self.error(err, id);
+    orig_log.call(this, data, stream)
   }
 
   if (typeof callback === 'function') {
@@ -84,7 +72,7 @@ exports.time = function(arg1, arg2, arg3) {
 }
 
 exports.namespace = function(object) {
-  var logfmt    = require('../logfmt');
+  var logfmt = require('../logfmt');
   var namespace = _.extend({}, this.defaultData, object);
   return new logfmt(this.stream, namespace);
 }

--- a/test/log_time.js
+++ b/test/log_time.js
@@ -1,4 +1,4 @@
-var logfmt = new require('../logfmt'),
+var logfmt = require('../logfmt'),
     assert = require('assert');
 
 var OutStream = require('./outstream');
@@ -26,6 +26,13 @@ suite('logfmt.time', function() {
     })
   })
 
+  test("logs the time with your label if no callback is provided", function(){
+    var logger = logfmt.time('time')
+    logger.log();
+    var actual = logfmt.stream.logline;
+    assert(/^time=\dms\n$/.test(actual), actual)
+  })
+
   test("logs the time with your label and persistent data", function(done){
     logfmt.time('time', {foo: 'bar'}, function(logger){
       logger.log();
@@ -42,7 +49,7 @@ suite('logfmt.time', function() {
       assert(/^foo=bar elapsed=\d+ms\n$/.test(actual), actual)
       logger.log({moar: 'data'});
       var actual = logfmt.stream.logline;
-      assert(/^moar=data foo=bar elapsed=\d+ms\n$/.test(actual), actual)
+      assert(/^foo=bar moar=data elapsed=\d+ms\n$/.test(actual), actual)
       done();
     })
   })
@@ -94,12 +101,21 @@ suite('logfmt.time', function() {
     });
   })
 
-  test("returns a logger", function(){
+  test("returns a logfmt", function(){
     var logger1, logger2;
     logger1 = logfmt.time(function(logger){
       logger2 = logger;
     });
     assert.equal(logger1, logger2);
+  })
+
+  test('logger is a proper logfmt object', function(){
+    var logger1 = logfmt.time({foo: 'bar'});
+    var logfmt2 = new logfmt();
+
+    for(var prop in logfmt2){
+      assert(logger1[prop]);
+    }
   })
 
   // tests you can pass the logger into a closure

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
 --ui tdd
 --reporter spec
+--check-leaks

--- a/test/namespace_time.js
+++ b/test/namespace_time.js
@@ -1,4 +1,4 @@
-var logfmt = require('../logfmt'),
+var logfmt = new require('../logfmt'),
     assert = require('assert');
 
 var OutStream = require('./outstream');
@@ -37,7 +37,7 @@ suite('logfmt.namespace.time', function() {
       assert(/^ns=logfmt foo=bar elapsed=\dms\n$/.test(actual), actual)
       logger.log({moar: 'data'});
       var actual = logfmt2.stream.logline;
-      assert(/^ns=logfmt moar=data foo=bar elapsed=\dms\n$/.test(actual),
+      assert(/^ns=logfmt foo=bar moar=data elapsed=\dms\n$/.test(actual),
               actual)
       done();
     })

--- a/test/new_logfmt.js
+++ b/test/new_logfmt.js
@@ -23,7 +23,7 @@ suite('new logfmt', function() {
   })
 
   test('constructor accepts a stream', function(){
-    stream = new OutStream;
+    var stream = new OutStream;
     var logfmt2 = new logfmt(stream);
     var data = {foo: 'bar', a: 14}
     logfmt2.log(data);


### PR DESCRIPTION
FINALLY!

`logfmt.time` uses `namespace` to return a new logfmt object instead of the ghetto, mocked logger object
