### PR TITLE
Upgrade to current stable lodash 4.x series.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "split": "0.2.x",
     "through": "2.3.x",
-    "lodash": "~2.4.1"
+    "lodash": "4.x"
   },
   "devDependencies": {
     "express": "3.3.x",


### PR DESCRIPTION
Courtesy upgrade to allow modern projects to install/bundle fewer versions of lodash.