### PR TITLE
Build against current Node.js and the latest LTS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "node"
+  - "8.10.0"


### PR DESCRIPTION
The symbolic "node" builds against the current stable series, and the last LTS is in there for good measure.