### PR TITLE
Remove lodash

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,10 +1,8 @@
-var _ = require('lodash');
-
 exports.log = function(data, stream) {
   this.stream = this.stream || process.stdout;
   if(stream == undefined) stream = this.stream;
 
-  var logData = _.extend({}, this.defaultData, data);
+  var logData = Object.assign({}, this.defaultData, data);
 
   if(this.timers){
     for(var key in this.timers){
@@ -23,7 +21,7 @@ exports.time = function(label) {
   var timer  = new logfmt();
   timer.stream = this.stream;
   timer.defaultData = this.defaultData;
-  timer.timers = _.extend({}, this.timers)
+  timer.timers = Object.assign({}, this.timers)
   timer.timers[label] = startTime;
   return timer;
 }
@@ -31,7 +29,7 @@ exports.time = function(label) {
 exports.namespace = function(object) {
   var logfmt = require('../logfmt');
   var namespaced = new logfmt()
-  var namespace  = _.extend({}, this.defaultData, object);
+  var namespace  = Object.assign({}, this.defaultData, object);
   namespaced.stream = this.stream;
   namespaced.defaultData = namespace
   namespaced.timers = this.timers;
@@ -44,8 +42,8 @@ exports.error = function(err, id) {
     id = Math.random().toString().slice(2, 12);
   }
   var errorLogger = this.namespace({
-    error: true, 
-    id:id, 
+    error: true,
+    id:id,
     now: (new Date()).toISOString()
   })
   errorLogger.log({ message:err.message });

--- a/logfmt.js
+++ b/logfmt.js
@@ -3,7 +3,6 @@ function logfmt() {
 }
 module.exports = logfmt;
 
-var _                = require('lodash');
 var streaming        = require('./lib/streaming');
 var bodyParser       = require('./lib/body_parser');
 var bodyParserStream = require('./lib/body_parser_stream');
@@ -13,8 +12,8 @@ var requestLogger    = require('./lib/request_logger');
 var serializer       = require('./lib/stringify');
 
 //Build up logfmt prototype
-_.extend(logfmt.prototype, logger);
-_.extend(logfmt.prototype, streaming);
+Object.assign(logfmt.prototype, logger);
+Object.assign(logfmt.prototype, streaming);
 
 logfmt.prototype.stringify = serializer.stringify;
 logfmt.prototype.parse = logfmtParser.parse;
@@ -39,4 +38,4 @@ logfmt.prototype.requestLogger = function(options, formatter) {
 
 logfmt.prototype.requestLogger.commonFormatter = requestLogger.commonFormatter;
 
-_.extend(logfmt, logfmt.prototype);
+Object.assign(logfmt, logfmt.prototype);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "logfmt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "asn1": {
       "version": "0.2.3",
@@ -26,13 +27,20 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -50,7 +58,13 @@
       "version": "1.8.12",
       "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
       "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
     },
     "bytes": {
       "version": "0.2.0",
@@ -62,7 +76,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-1.2.0.tgz",
       "integrity": "sha1-/VcTv6FTx9bMWZN4patMRcU1Ap4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "keypress": "0.1.x"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -74,7 +91,21 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/connect/-/connect-2.8.8.tgz",
       "integrity": "sha1-uav4yvC9l3PLPeopNEEZhyWCRG0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "bytes": "0.2.0",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "formidable": "1.0.14",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "pause": "0.0.1",
+        "qs": "0.6.5",
+        "send": "0.1.4",
+        "uid2": "0.0.2"
+      }
     },
     "cookie": {
       "version": "0.1.0",
@@ -98,7 +129,13 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/csv/-/csv-1.2.1.tgz",
       "integrity": "sha1-UjHt/BxxUlEuxFeBB2p6l/9SXAw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "csv-generate": "^1.1.2",
+        "csv-parse": "^1.3.3",
+        "csv-stringify": "^1.1.2",
+        "stream-transform": "^0.2.2"
+      }
     },
     "csv-generate": {
       "version": "1.1.2",
@@ -116,19 +153,28 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
       "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash.get": "~4.4.2"
+      }
     },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "detect-node": {
       "version": "2.0.3",
@@ -147,14 +193,20 @@
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
       "integrity": "sha1-QooiOv4DQl0s1tY0f99AxmkDVj0=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "nan": "^2.3.3"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
     },
     "escape-regexp-component": {
       "version": "1.0.2",
@@ -172,13 +224,29 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ewma/-/ewma-2.0.1.tgz",
       "integrity": "sha512-MYYK17A76cuuyvkR7MnqLW4iFYPEi5Isl2qb8rXiWpLiwFS9dxW/rncuNnjjgSENuVqZQkIuR4+DChVL4g1lnw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "express": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/express/-/express-3.3.8.tgz",
       "integrity": "sha1-jpisMNgfTJW4XXHSr2z4T2LvGb0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.1",
+        "commander": "1.2.0",
+        "connect": "2.8.8",
+        "cookie": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "mkdirp": "0.3.5",
+        "range-parser": "0.0.4",
+        "send": "0.1.4"
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -196,7 +264,11 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-1.13.0.tgz",
       "integrity": "sha512-aIa4UTxZ3klfApaQEJJ5cQvNeqfrxVngcjMgy+G5ygkrOrDPkORhY/RMH6F8mLwBpPt3Z0F03CtzN7gs2Q5H1w==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fast-decode-uri-component": "^1.0.0",
+        "safe-regex": "^1.1.0"
+      }
     },
     "formidable": {
       "version": "1.0.14",
@@ -220,13 +292,24 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "growl": {
       "version": "1.10.5",
@@ -256,7 +339,13 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -268,13 +357,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -305,18 +403,19 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "keypress": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
       "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=",
       "dev": true
-    },
-    "lodash": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-      "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -328,7 +427,11 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "methods": {
       "version": "0.0.1",
@@ -352,7 +455,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -371,6 +477,19 @@
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
       "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
       "dependencies": {
         "commander": {
           "version": "2.15.1",
@@ -382,7 +501,10 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         }
       }
     },
@@ -405,13 +527,21 @@
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
       "dependencies": {
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         }
       }
     },
@@ -445,7 +575,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -493,13 +626,46 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "restify": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/restify/-/restify-7.2.0.tgz",
       "integrity": "sha512-UXYtu437a5TSim0PgjCiccdUfQS/00VC9gDxqR2/GKaW19OtY3DYDg3HByCAnyO5GiL2y0pBI572wGcxZGP26A==",
       "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "bunyan": "^1.8.12",
+        "csv": "^1.1.1",
+        "dtrace-provider": "^0.8.1",
+        "escape-regexp-component": "^1.0.2",
+        "ewma": "^2.0.1",
+        "find-my-way": "^1.12.0",
+        "formidable": "^1.2.1",
+        "http-signature": "^1.2.0",
+        "lodash": "^4.17.10",
+        "lru-cache": "^4.1.3",
+        "mime": "^1.5.0",
+        "negotiator": "^0.6.1",
+        "once": "^1.4.0",
+        "pidusage": "^1.2.0",
+        "qs": "^6.5.2",
+        "restify-errors": "^5.0.0",
+        "semver": "^5.4.1",
+        "spdy": "^3.4.7",
+        "uuid": "^3.1.0",
+        "vasync": "^1.6.4",
+        "verror": "^1.10.0"
+      },
       "dependencies": {
         "formidable": {
           "version": "1.2.1",
@@ -532,6 +698,12 @@
       "resolved": "https://registry.npmjs.org/restify-errors/-/restify-errors-5.0.0.tgz",
       "integrity": "sha512-+vby9Kxf7qlzvbZSTIEGkIixkeHG+pVCl34dk6eKnL+ua4pCezpdLT/1/eabzPZb65ADrgoc04jeWrrF1E1pvQ==",
       "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "lodash": "^4.2.1",
+        "safe-json-stringify": "^1.0.3",
+        "verror": "^1.8.1"
+      },
       "dependencies": {
         "lodash": {
           "version": "4.17.10",
@@ -553,13 +725,23 @@
       "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "glob": "^6.0.1"
+      },
       "dependencies": {
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -580,7 +762,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
     },
     "select-hose": {
       "version": "2.0.0",
@@ -598,19 +783,36 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/send/-/send-0.1.4.tgz",
       "integrity": "sha1-vnDY0b4B3mGCGvE3gLUDRaT3Gr0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "*",
+        "fresh": "0.2.0",
+        "mime": "~1.2.9",
+        "range-parser": "0.0.4"
+      }
     },
     "spdy": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -619,25 +821,50 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
       "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
       "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
     "split": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc="
+      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+      "requires": {
+        "through": "2"
+      }
     },
     "sshpk": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
+      }
     },
     "stream-transform": {
       "version": "0.2.2",
@@ -649,13 +876,19 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "through": {
       "version": "2.3.8",
@@ -692,6 +925,9 @@
       "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.4.tgz",
       "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
       "dev": true,
+      "requires": {
+        "verror": "1.6.0"
+      },
       "dependencies": {
         "extsprintf": {
           "version": "1.2.0",
@@ -703,7 +939,10 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
           "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "extsprintf": "1.2.0"
+          }
         }
       }
     },
@@ -711,13 +950,21 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "wbuf": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "^1.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "split": "0.2.x",
-    "through": "2.3.x",
-    "lodash": "4.x"
+    "through": "2.3.x"
   },
   "devDependencies": {
     "express": "3.3.x",


### PR DESCRIPTION
4 years ago, on March 11, 2014, I made the decision to add lodash to node-logfmt.

Now, 4 years later, I'd like to remove it :)

I'm using node-logfmt in a webpack project, and it adds like 500kB to my bundle size. We could just import `lodash/extend`, but with `Object.assign` available in all non-deprecated versions of Node, it's no longer necessary.