### PR TITLE
Update stringify.js to quote values containing quotes

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -14,7 +14,7 @@ exports.stringify = function(data){
     var needs_escaping = value.indexOf('"') > -1 || value.indexOf("\\") > -1;
 
     if(needs_escaping) value = value.replace(/["\\]/g, '\\$&');
-    if(needs_quoting) value = '"' + value + '"';
+    if(needs_quoting || needs_escaping) value = '"' + value + '"';
     if(value === '' && !is_null) value = '""';
 
     line += key + '=' + value + ' ';


### PR DESCRIPTION
If a value contains quotes, they must be escaped _and_ the value must be surrounded by un-escaped quotes. Update the stringify logic to reflect this